### PR TITLE
Set application home directory to permit 'test', static file service

### DIFF
--- a/bin/pastebeest
+++ b/bin/pastebeest
@@ -8,7 +8,7 @@ BEGIN { unshift @INC, "$FindBin::Bin/../app" }
 use Mojolicious::Commands;
 
 # Assume this script lies one directory below the application's home dir
-$ENV{MOJO_HOME} =  Mojo::File->new(__FILE__)->realpath->dirname->dirname;
+$ENV{MOJO_HOME} =  Mojo::File->new($FindBin::Bin)->realpath->dirname;
 
 # Start command line interface for application
 Mojolicious::Commands->start_app('Pastebeest');

--- a/bin/pastebeest
+++ b/bin/pastebeest
@@ -7,5 +7,8 @@ use FindBin;
 BEGIN { unshift @INC, "$FindBin::Bin/../app" }
 use Mojolicious::Commands;
 
+# Assume this script lies one directory below the application's home dir
+$ENV{MOJO_HOME} =  Mojo::File->new(__FILE__)->realpath->dirname->dirname;
+
 # Start command line interface for application
 Mojolicious::Commands->start_app('Pastebeest');


### PR DESCRIPTION
By default, Mojo::Home::detect() looks for script's directory and removes 'lib' from the end. This fails because we place the script in 'bin' so we override by explictly setting the $ENV{MOJO_HOME}.